### PR TITLE
Declare M6502_log_printall in lib6502.h

### DIFF
--- a/lib6502.h
+++ b/lib6502.h
@@ -61,6 +61,7 @@ extern void   M6502_run(M6502 *mpu);
 extern int    M6502_disassemble(M6502 *mpu, uint16_t addr, char buffer[64]);
 extern void   M6502_dump(M6502 *mpu, char buffer[64]);
 extern void   M6502_delete(M6502 *mpu);
+extern void   M6502_log_printall(void);
 
 #define M6502_getVector(MPU, VEC)			\
   ( ( ((MPU)->memory[M6502_##VEC##VectorLSB]) )		\


### PR DESCRIPTION
This allows `make` to succeed on a vanilla Mac OS X machine, which has stopped supporting implicit function declarations by default.

```
run6502.c:409:2: error: call to undeclared function 'M6502_log_printall'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        M6502_log_printall();
        ^
```

Closes #2.